### PR TITLE
Add spaces before line continuations in Justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -66,72 +66,72 @@ fix_format: _install_format
 #
 # Lints the project source code
 lint: _install_lint
-    cargo clippy --\
-     -F absolute_paths_not_starting_with_crate\
-     -F anonymous_parameters\
-     -A box_pointers\
-     -F deprecated_in_future\
-     -D elided_lifetimes_in_paths\
-     -D explicit_outlives_requirements\
-     -F indirect_structural_match\
-     -F keyword_idents\
-     -F macro_use_extern_crate\
-     -F meta_variable_misuse\
-     -F missing_copy_implementations\
-     -F missing_debug_implementations\
-     -F missing_docs\
-     -F missing_doc_code_examples\
-     -F non_ascii_idents\
-     -F private_doc_tests\
-     -F single_use_lifetimes\
-     -F trivial_casts\
-     -F trivial_numeric_casts\
-     -F unreachable_pub\
-     -F unsafe_code\
-     -D unused_extern_crates\
-     -F unused_import_braces\
-     -F unused_lifetimes\
-     -D unused_qualifications\
-     -D unused_results\
-     -A variant_size_differences\
-     -F warnings\
-     -D redundant_semicolons\
-     -D unreachable_code\
-     -D unused_variables\
-     -F ambiguous_associated_items\
-     -F arithmetic_overflow\
-     -F conflicting_repr_hints\
-     -F const_err\
-     -F ill_formed_attribute_input\
-     -F invalid_type_param_default\
-     -F macro_expanded_macro_exports_accessed_by_absolute_paths\
-     -F missing_fragment_specifier\
-     -F mutable_transmutes\
-     -F no_mangle_const_items\
-     -F order_dependent_trait_objects\
-     -F overflowing_literals\
-     -F patterns_in_fns_without_body\
-     -F pub_use_of_private_extern_crate\
-     -F soft_unstable\
-     -F unconditional_panic\
-     -F unknown_crate_types\
-     -F clippy::correctness\
-     -F clippy::restriction\
-     -F clippy::style\
-     -F clippy::pedantic\
-     -F clippy::complexity\
-     -F clippy::perf\
-     -F clippy::cargo\
-     -F clippy::nursery\
-     -D clippy::missing_const_for_fn\
-     -D clippy::useless_attribute\
-     -A clippy::empty_enum\
-     -A clippy::multiple_crate_versions\
-     -A clippy::implicit_return\
-     -D clippy::indexing_slicing\
-     -D clippy::missing_inline_in_public_items\
-     -D clippy::unreachable\
-     -D clippy::use_self\
+    cargo clippy -- \
+     -F absolute_paths_not_starting_with_crate \
+     -F anonymous_parameters \
+     -A box_pointers \
+     -F deprecated_in_future \
+     -D elided_lifetimes_in_paths \
+     -D explicit_outlives_requirements \
+     -F indirect_structural_match \
+     -F keyword_idents \
+     -F macro_use_extern_crate \
+     -F meta_variable_misuse \
+     -F missing_copy_implementations \
+     -F missing_debug_implementations \
+     -F missing_docs \
+     -F missing_doc_code_examples \
+     -F non_ascii_idents \
+     -F private_doc_tests \
+     -F single_use_lifetimes \
+     -F trivial_casts \
+     -F trivial_numeric_casts \
+     -F unreachable_pub \
+     -F unsafe_code \
+     -D unused_extern_crates \
+     -F unused_import_braces \
+     -F unused_lifetimes \
+     -D unused_qualifications \
+     -D unused_results \
+     -A variant_size_differences \
+     -F warnings \
+     -D redundant_semicolons \
+     -D unreachable_code \
+     -D unused_variables \
+     -F ambiguous_associated_items \
+     -F arithmetic_overflow \
+     -F conflicting_repr_hints \
+     -F const_err \
+     -F ill_formed_attribute_input \
+     -F invalid_type_param_default \
+     -F macro_expanded_macro_exports_accessed_by_absolute_paths \
+     -F missing_fragment_specifier \
+     -F mutable_transmutes \
+     -F no_mangle_const_items \
+     -F order_dependent_trait_objects \
+     -F overflowing_literals \
+     -F patterns_in_fns_without_body \
+     -F pub_use_of_private_extern_crate \
+     -F soft_unstable \
+     -F unconditional_panic \
+     -F unknown_crate_types \
+     -F clippy::correctness \
+     -F clippy::restriction \
+     -F clippy::style \
+     -F clippy::pedantic \
+     -F clippy::complexity \
+     -F clippy::perf \
+     -F clippy::cargo \
+     -F clippy::nursery \
+     -D clippy::missing_const_for_fn \
+     -D clippy::useless_attribute \
+     -A clippy::empty_enum \
+     -A clippy::multiple_crate_versions \
+     -A clippy::implicit_return \
+     -D clippy::indexing_slicing \
+     -D clippy::missing_inline_in_public_items \
+     -D clippy::unreachable \
+     -D clippy::use_self \
      -D clippy::module_name_repetitions
 
 # Create pull request for resolving <issue_num>


### PR DESCRIPTION
Hi there!

it looks like an upcoming change to Just may break your justfile, so I wanted to preemptively open this PR with a fix.

The change is here: https://github.com/casey/just/pull/635

The change makes line continuations strip leading whitespace on the following line, which improves the formatting when commands are echoed.

So for example, if you have this justfile:

```
foo:
  echo bar \
    baz
```

The command would have previously been `echo bar  baz`, but will now be `echo bar baz`.

Since the shell ignores whitespace, this is mostly a no-op, but will break lines where there isn't a space before the slash:

```
# This recipe will run `echo barbaz`, which is probably not desired.
foo:
  echo bar\
    baz
```

The benefit to this change is that lines with multiple continuations will now be formatted much more nicely when echoed. For example, running this justfile:

```
foo:
  echo foo \
    --bar \
    --baz
```

Currently prints:

```
echo foo   --bar   --baz
```

And after this change it will print  `echo foo --bar --baz`.

I personally think this change is worth it, but if you don't, I'd definitely be interested in your opinion!